### PR TITLE
add travis file (Fix #8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - 1.13.x
+
+script: go test -v ./...


### PR DESCRIPTION
This simply adds the most basic travis configuration for a go project.