### PR TITLE
Fix wrong io names. gofmt some files

### DIFF
--- a/commands/case.go
+++ b/commands/case.go
@@ -54,7 +54,7 @@ func AddNewCaseInput(inputLines []string,
 	if err != nil {
 		return metaData, err
 	}
-	inputFile := config.NewIoFile(inputFileName, path.Join("inputs", inputFileName), true)
+	inputFile := config.NewIoFile(caseName, path.Join("inputs", inputFileName), true)
 	metaData.Inputs = append(metaData.Inputs, inputFile)
 
 	return metaData, nil
@@ -70,7 +70,7 @@ func AddNewCaseOutput(outputLines []string,
 	if err != nil {
 		return metaData, err
 	}
-	outputFile := config.NewIoFile(outputFileName, path.Join("outputs", outputFileName), true)
+	outputFile := config.NewIoFile(caseName, path.Join("outputs", outputFileName), true)
 	metaData.Outputs = append(metaData.Outputs, outputFile)
 
 	return metaData, nil
@@ -133,10 +133,10 @@ func CustomCaseAction(context *cli.Context) error {
 }
 
 // Command to add costum test cases to the current task.
-// Running this command will ask the user to provide their input and output, then 
+// Running this command will ask the user to provide their input and output, then
 // saves the new test case data into appropriate files and add their meta data into
 // the current task egor meta data.
-// The user can add a flag --no-output to specify that this test case have no output 
+// The user can add a flag --no-output to specify that this test case have no output
 // associated with it. The user will not be asked to provide output in this case.
 var CaseCommand = cli.Command{
 	Name:      "case",

--- a/commands/case_test.go
+++ b/commands/case_test.go
@@ -4,38 +4,37 @@ import (
 	"github.com/chermehdi/egor/config"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path"
 	"testing"
 )
 
-
-func createDummyMetaData() (config.EgorMeta) {
-	meteData := config.EgorMeta {
-		TaskName:	"Dummy Task",
-		TaskLang: 	"cpp",
-		Inputs: 	[]config.IoFile {
-			config.IoFile {
-				Name: 	"test-0",
-				Path: 	"inputs/test-0.in",
-				Custom:	false, 
-			}, 
-			config.IoFile {
-				Name: 	"test-1",
-				Path: 	"inputs/test-1.in",
-				Custom:	true,
-			}, 
-		}, 
-		Outputs: 	[]config.IoFile {
-			config.IoFile {
-				Name: 	"test-0",
-				Path: 	"outputs/test-0.ans",
-				Custom:	false,
+func createDummyMetaData() config.EgorMeta {
+	meteData := config.EgorMeta{
+		TaskName: "Dummy Task",
+		TaskLang: "cpp",
+		Inputs: []config.IoFile{
+			config.IoFile{
+				Name:   "test-0",
+				Path:   "inputs/test-0.in",
+				Custom: false,
+			},
+			config.IoFile{
+				Name:   "test-1",
+				Path:   "inputs/test-1.in",
+				Custom: true,
+			},
+		},
+		Outputs: []config.IoFile{
+			config.IoFile{
+				Name:   "test-0",
+				Path:   "outputs/test-0.ans",
+				Custom: false,
 			},
 		},
 	}
 
 	return meteData
 }
-
 
 func TestAddNewCaseInput(t *testing.T) {
 	meteData := createDummyMetaData()
@@ -50,11 +49,11 @@ func TestAddNewCaseInput(t *testing.T) {
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(meteData.Inputs), 3)
-	assert.Equal(t, meteData.Inputs[2].Name, caseName + ".in")
+	assert.Equal(t, meteData.Inputs[2].Name, caseName)
+	assert.Equal(t, meteData.Inputs[2].Path, path.Join("inputs", caseName+".in"))
 	assert.Equal(t, meteData.Inputs[2].Custom, true)
-	
-}
 
+}
 
 func TestAddNewCaseOutput(t *testing.T) {
 	meteData := createDummyMetaData()
@@ -69,7 +68,8 @@ func TestAddNewCaseOutput(t *testing.T) {
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(meteData.Outputs), 2)
-	assert.Equal(t, meteData.Outputs[1].Name, caseName + ".ans")
+	assert.Equal(t, meteData.Outputs[1].Name, caseName)
+	assert.Equal(t, meteData.Outputs[1].Path, path.Join("outputs", caseName+".ans"))
 	assert.Equal(t, meteData.Outputs[1].Custom, true)
 
 }

--- a/commands/showcases.go
+++ b/commands/showcases.go
@@ -10,11 +10,11 @@ import (
 )
 
 type TestCaseIO struct {
-	Id int
-	Name string
-	InputPath string
+	Id         int
+	Name       string
+	InputPath  string
 	OutputPath string
-	Custom bool
+	Custom     bool
 }
 
 // parse input and output from egor meta to TestCase
@@ -22,12 +22,12 @@ func GetTestCases(egorMeta config.EgorMeta) []*TestCaseIO {
 	testCasesMap := make(map[string]*TestCaseIO)
 	testCases := make([]*TestCaseIO, 0)
 	for _, input := range egorMeta.Inputs {
-		testCase := &TestCaseIO {
-			Id : input.GetId(),
-			Name : input.Name,
-			InputPath : input.Path,
+		testCase := &TestCaseIO{
+			Id:         input.GetId(),
+			Name:       input.Name,
+			InputPath:  input.Path,
 			OutputPath: "",
-			Custom: input.Custom,
+			Custom:     input.Custom,
 		}
 		testCasesMap[input.Name] = testCase
 		testCases = append(testCases, testCase)
@@ -89,7 +89,7 @@ func ShowCasesAction(context *cli.Context) error {
 
 	color.Green("Listing %d testcase(s)...", metaData.CountTestCases())
 	color.Green("")
-	
+
 	PrintTestCases(metaData)
 
 	return nil

--- a/commands/showcases_test.go
+++ b/commands/showcases_test.go
@@ -6,22 +6,22 @@ import (
 	"testing"
 )
 
-func createSimpleDummyMetaData() config.EgorMeta{
-	meteData := config.EgorMeta {
-		TaskName:	"Dummy Task",
-		TaskLang: 	"cpp",
-		Inputs: 	[]config.IoFile {
-			config.IoFile {
-				Name: 	"test-0",
-				Path: 	"inputs/test-0.in",
-				Custom:	true, 
-			}, 
-		}, 
-		Outputs: 	[]config.IoFile {
-			config.IoFile {
-				Name: 	"test-0",
-				Path: 	"outputs/test-0.ans",
-				Custom:	true,
+func createSimpleDummyMetaData() config.EgorMeta {
+	meteData := config.EgorMeta{
+		TaskName: "Dummy Task",
+		TaskLang: "cpp",
+		Inputs: []config.IoFile{
+			config.IoFile{
+				Name:   "test-0",
+				Path:   "inputs/test-0.in",
+				Custom: true,
+			},
+		},
+		Outputs: []config.IoFile{
+			config.IoFile{
+				Name:   "test-0",
+				Path:   "outputs/test-0.ans",
+				Custom: true,
 			},
 		},
 	}


### PR DESCRIPTION
Fixing wrong inputs and outputs names.
This pr includes a run of a gofmt on some files.

Closes #12 