### PR TITLE
Default the task time limit to 10000 if is 0

### DIFF
--- a/commands/parse.go
+++ b/commands/parse.go
@@ -5,10 +5,6 @@ import (
 	"context"
 	json2 "encoding/json"
 	"fmt"
-	. "github.com/chermehdi/egor/config"
-	"github.com/chermehdi/egor/templates"
-	"github.com/fatih/color"
-	"github.com/urfave/cli/v2"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -16,6 +12,11 @@ import (
 	"strings"
 	template2 "text/template"
 	"time"
+
+	. "github.com/chermehdi/egor/config"
+	"github.com/chermehdi/egor/templates"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
 )
 
 const listenAddr = ":4243"
@@ -100,6 +101,7 @@ func CreateDirectoryStructure(task Task, config Config, rootDir string) (string,
 // it will parse it as a json Task and return it.
 func extractTaskFromJson(json string) (*Task, error) {
 	var task Task
+	task.TimeLimit = 10000 // default timelimit to 10 seconds
 	err := json2.Unmarshal([]byte(json), &task)
 	if err != nil {
 		return nil, err

--- a/commands/run.go
+++ b/commands/run.go
@@ -478,6 +478,7 @@ func NewJudgeFor(meta config.EgorMeta, configuration *config.Config) (Judge, err
 	case "java":
 		return &JavaJudge{Meta: meta, checker: &DiffChecker{}}, nil
 	case "cpp":
+		return &CppJudge{Meta: meta, checker: &DiffChecker{}, hasLibrary: configuration.HasCppLibrary(), LibraryLocation: configuration.CppLibraryLocation}, nil
 	case "c":
 		return &CppJudge{Meta: meta, checker: &DiffChecker{}, hasLibrary: configuration.HasCppLibrary(), LibraryLocation: configuration.CppLibraryLocation}, nil
 	case "python":

--- a/config/meta.go
+++ b/config/meta.go
@@ -75,6 +75,9 @@ func NewEgorMeta(task Task, config Config) EgorMeta {
 	if err != nil {
 		panic(err)
 	}
+	if task.TimeLimit == 0 {
+		task.TimeLimit = 10000
+	}
 	return EgorMeta{
 		TaskName:  task.Name,
 		TaskLang:  config.Lang.Default,

--- a/config/meta.go
+++ b/config/meta.go
@@ -75,9 +75,6 @@ func NewEgorMeta(task Task, config Config) EgorMeta {
 	if err != nil {
 		panic(err)
 	}
-	if task.TimeLimit == 0 {
-		task.TimeLimit = 10000
-	}
 	return EgorMeta{
 		TaskName:  task.Name,
 		TaskLang:  config.Lang.Default,


### PR DESCRIPTION
Set default time limit to 10 seconds if equal to 0. This should fix the issue when the time limit is not specified in some problems.
