### PR TITLE
Compress expected and got output when diff

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -60,9 +60,18 @@ type DiffChecker struct {
 func (c *DiffChecker) Check(got, expected string) error {
 	// Compare the trimmed output from both input and output
 	if strings.TrimRight(got, " \t\n\r") != strings.TrimRight(expected, " \t\n\r") {
-		return errors.New(fmt.Sprintf("Checker failed, expected:\n%s\nfound:\n%s", expected, got))
+		return errors.New(fmt.Sprintf("Checker failed, expected:\n%s\nfound:\n%s", Compress(expected), Compress(got)))
 	}
 	return nil
+}
+
+// Compress a string to at most 64 characters.
+func Compress(s string) string {
+	if len(s) <= 64 {
+		return s
+	}
+
+	return s[0:30] + "..." + s[len(s)-31:]
 }
 
 // Case description contains minimum information required to run one test case.

--- a/commands/run_test.go
+++ b/commands/run_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,4 +20,12 @@ func TestTimedExecution(t *testing.T) {
 	status, _, err := timedExecution(cmd, 1000+TimeOutDelta)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, status, OK)
+}
+
+func TestCompress(t *testing.T) {
+	got1 := strings.Repeat("a", 64)
+	got2 := strings.Repeat("a", 65)
+	expected2 := strings.Repeat("a", 30) + "..." + strings.Repeat("a", 31)
+	assert.Equal(t, Compress(got1), got1)
+	assert.Equal(t, Compress(got2), expected2)
 }


### PR DESCRIPTION
This will limit the expected and got output to 64 characters in case  of difference.
This works perfectly in case of one single line output, but the output difference may look a little weird in general case. The reason is the current diff checker treats the output as a single string.

Closes #39 