### PR TITLE
Feature/display warnings

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -378,9 +378,12 @@ func (judge *CppJudge) compile(currentDir, fileName string) error {
 	cmd := exec.Command("g++", "--std=c++14", fileName, "-o", "work/sol")
 	cmd.Dir = currentDir
 	cmd.Stderr = &stderrBuffer
-	if err := cmd.Run(); err != nil {
+	err := cmd.Run()
+	if err != nil {
 		color.Red("Could not  compile, Cause: \n%s", stderrBuffer.String())
 		return err
+	} else if stderrBuffer.String() != "" {
+	   color.Yellow("Warnings:\n%s\n", stderrBuffer.String());
 	}
 	return nil
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -375,7 +375,7 @@ func (judge *CppJudge) hasLibraryLocation() bool {
 // We expect fileName to be: main.cpp or main_gen.cpp.
 func (judge *CppJudge) compile(currentDir, fileName string) error {
 	var stderrBuffer bytes.Buffer
-	cmd := exec.Command("g++", "--std=c++14", fileName, "-o", "work/sol")
+	cmd := exec.Command("g++", "--std=c++14", fileName, "-o", "work/sol", "-Wall")
 	cmd.Dir = currentDir
 	cmd.Stderr = &stderrBuffer
 	err := cmd.Run()


### PR DESCRIPTION
Now in commands/run.go if stderr is not empty when running the build command for c++ egor displays it (a.k.a the warnings)