### PR TITLE
Release 0.4.0: update skimo version to keep docs after inlining

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const LatestVersion = "0.2.0"
+const LatestVersion = "0.4.0"
 
 // The configuration of the CLI
 type Config struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/atotto/clipboard v0.1.2
-	github.com/chermehdi/skimo v0.0.3
+	github.com/chermehdi/skimo v0.0.4
 	github.com/fatih/color v1.9.0
 	github.com/go-openapi/strfmt v0.19.4 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/chermehdi/skimo v0.0.2 h1:jM50/JiaHcdsgrkGDh4UFZSnEqTDiUk4Finglpddsf0
 github.com/chermehdi/skimo v0.0.2/go.mod h1:IyNiK9Qhq9hRCM+oNhR51kh3If0HzLGE4Zr5Fv9Ogds=
 github.com/chermehdi/skimo v0.0.3 h1:szEajpxODufNkIgXmJIHPwdRKQs7HuHmt34CxSeI+lA=
 github.com/chermehdi/skimo v0.0.3/go.mod h1:IyNiK9Qhq9hRCM+oNhR51kh3If0HzLGE4Zr5Fv9Ogds=
+github.com/chermehdi/skimo v0.0.4 h1:8X97r5N/GiD3cK0zpIALw7fV7kW/UJUFDUJOcSEn8PE=
+github.com/chermehdi/skimo v0.0.4/go.mod h1:IyNiK9Qhq9hRCM+oNhR51kh3If0HzLGE4Zr5Fv9Ogds=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
New Release:

- Update `skimo` version to  keep docs added to the top of the main solution file after inlining in `cpp` solutions.