### PR TITLE
Replace deprecated std::random_shuffle

### DIFF
--- a/templates/resolver.go
+++ b/templates/resolver.go
@@ -141,6 +141,8 @@ class Rand {
   // an std::string of size 10 consisting only of lowercase letters and digits
   std::string String(size_t size, const int mask = LOWER | UPPER) {
     std::string charset;
+    std::random_device rd;
+    std::mt19937 g(rd());
 
     // Building the set of allowed charset from the mask
     if (mask & LOWER) {
@@ -153,7 +155,7 @@ class Rand {
       charset += DIGITS_SET;
     }
 
-    std::random_shuffle(charset.begin(), charset.end());
+    std::shuffle(charset.begin(), charset.end(), g);
 
     std::string res(size, ' ');
 


### PR DESCRIPTION
std::random_shuffle is deprecated in c++ 14 and removed in c++ 17. 

This may need further cleanup, if you have any other suggestions of how to fix this let me know so I can fix it in the PR.

fixes #71 