### PR TITLE
fix `egor config get config.templates.{lang}`, implementation was mis…

### DIFF
--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -16,6 +16,7 @@ func getDefaultConfiguration() *config.Config {
 		Lang: struct {
 			Default string `yaml:"default"`
 		}{Default: "cpp"},
+		CustomTemplate: make(map[string]string),
 	}
 }
 
@@ -29,6 +30,9 @@ func TestSetConfiguration(t *testing.T) {
 
 	_ = UpdateConfiguration(configuration, "lang.default", "java")
 	assert.Equal(t, configuration.Lang.Default, "java")
+
+    _ = UpdateConfiguration(configuration, "custom.templates.cpp", "/home/user/custom.cpp")
+    assert.Equal(t, configuration.CustomTemplate["cpp"], "/home/user/custom.cpp")
 }
 
 func TestSetConfigurationUnknownKey(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -132,6 +132,9 @@ func GetConfigurationValue(config *Config, key string) (string, error) {
 		return config.Author, nil
 	} else if lowerKey == "cpp.lib.location" {
 		return config.CppLibraryLocation, nil
+	} else if strings.HasPrefix(key,"config.templates") {
+    lang := key[strings.LastIndex(key,".") + 1:]
+    return config.CustomTemplate[lang], nil
 	} else {
 		return "", fmt.Errorf("Unknown config key %s", key)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -133,8 +133,8 @@ func GetConfigurationValue(config *Config, key string) (string, error) {
 	} else if lowerKey == "cpp.lib.location" {
 		return config.CppLibraryLocation, nil
 	} else if strings.HasPrefix(key,"config.templates") {
-    lang := key[strings.LastIndex(key,".") + 1:]
-    return config.CustomTemplate[lang], nil
+		lang := key[strings.LastIndex(key,".") + 1:]
+		return config.CustomTemplate[lang], nil
 	} else {
 		return "", fmt.Errorf("Unknown config key %s", key)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,6 +66,9 @@ func TestGetConfigurationValue(t *testing.T) {
 
 	_, err = GetConfigurationValue(config, "unknown.key")
 	assert.Error(t, err, "An error is returned if the configuration key is not known")
+
+    value, err = GetConfigurationValue(config, "config.templates")
+    assert.NoError(t, err,"No error should be thrown when getting custom template")
 }
 
 func TestConfig_HasCppLibrary(t *testing.T) {


### PR DESCRIPTION
command `egor config get config.templates.{lang}` was not implemented